### PR TITLE
Fixed line endings so gradlew executes on Unix

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -6,6 +6,7 @@
 ##
 ##############################################################################
 
+
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS=""
 
@@ -109,7 +110,6 @@ fi
 if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
-
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`


### PR DESCRIPTION
A CRLF after the shebang prevent scripts from working under Unix for some reason.
Replaced all LFs with CRLFs (in this file.)
Would it be a good idea to just change the initial CRLF to LF or is it a bad idea to mix line endings??
