### PR TITLE
Reworked MathHelper rounding to use BigDecimal

### DIFF
--- a/src/main/java/jaci/openrio/toast/lib/math/MathHelper.java
+++ b/src/main/java/jaci/openrio/toast/lib/math/MathHelper.java
@@ -1,5 +1,7 @@
 package jaci.openrio.toast.lib.math;
 
+import java.math.BigDecimal;
+
 /**
  * A utility class to help with Math
  *
@@ -11,7 +13,7 @@ public class MathHelper {
      * Round a number (d) to the specified amount of decimal places (res)
      */
     public static double round(double d, int res) {
-        int x = (int) Math.pow(10, res);
-        return Math.rint(d * x) / x;
+        BigDecimal bd = new BigDecimal(d).setScale(res, BigDecimal.ROUND_HALF_UP);
+        return bd.doubleValue();
     }
 }


### PR DESCRIPTION
I know it's only a two-line commit, but it was a quick fix that should be made. Feel free to copy/paste the code and commit it yourself instead of going through the hassle of pulling a PR.

Basically, because of how floating-point operations behave in Java, the traditional multiply -> cast -> round -> divide can cause inconsitencies in the data.

Fortunately, BigDecimal is meant for setting scale of numbers! It may also make sense to specify that this method is a decimal-point round and not a round based on significant figures.
