### PR TITLE
Simplify Travis packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.8
-      - g++-4.8
+      - libstdc++6
 
 install:
 - "./gradlew build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ addons:
     packages:
       - gcc-4.8
       - g++-4.8
-      - oracle-java8-installer
-      
+
 install:
 - "./gradlew build"
 - "./gradlew generateExternalPatches"


### PR DESCRIPTION
Removes `gcc-4.8`, `g++-4.8` and `oracle-java8-installer` from the apt packages installed and replaces them with `libstdc++6`, which is the only package we need to have installed for Travis to work with Toast.
