### PR TITLE
Actually fix AnalogInput blocking the main thread indefinitely

### DIFF
--- a/patches/src/main/java/edu/wpi/first/wpilibj/hal/AnalogJNI.java
+++ b/patches/src/main/java/edu/wpi/first/wpilibj/hal/AnalogJNI.java
@@ -76,7 +76,7 @@ public class AnalogJNI extends JNIWrapper {
 		// Everything fucking dies if this is set to 0. resetAccumulator() in AnalogInput runs 1.0 / getAnalogSampleRate(),
 		// which means 1.0 / 0 in floating point arithmetic, which equals Infinity, hence blocking the main thread indefinitely.
 		// 1 / 0 gives an exception, but 1.0 / 0 gives infinity. Welcome to floating point arithmetic.
-		return 1 / 25;
+		return 1 / 25d;
 	}
 	
 	public static boolean getAnalogTriggerInWindow(long analog_trigger_pointer){


### PR DESCRIPTION
1 / 25 gives 0, but 1 / 25d gives the fraction that we want. An integer divided by an integer will give an integer and since the value in this case is between 0 and 1, it would be truncated to 0. Welcome to floating point arithmetic in Java. :stuck_out_tongue_winking_eye:
