### PR TITLE
Add Servo to the Registrar

### DIFF
--- a/src/main/java/jaci/openrio/toast/lib/registry/Registrar.java
+++ b/src/main/java/jaci/openrio/toast/lib/registry/Registrar.java
@@ -160,6 +160,14 @@ public class Registrar<ID, Type> {
     }
 
     /**
+     * Get a Servo instance from the Registrar
+     * @param pwmPort the PWM port to use
+     */
+    public static Servo servo(int pwmPort) {
+        return pwmRegistrar.fetch(pwmPort, Servo.class, () -> { return new Servo(pwmPort); });
+    }
+
+    /**
      * Get a Talon SRX [CAN] instance from the Registrar
      * @param canID the CAN Device ID to use
      */


### PR DESCRIPTION
My team used a servo this season. When changing our base code to Toast, I noticed that servos weren't in the Registrar.
